### PR TITLE
Mejora React Native 0.63.3 - TypeError: undefined is not an object (e…

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -133,7 +133,7 @@ export default class Dropdown extends PureComponent {
     disabledItemColor: PropTypes.string,
     baseColor: PropTypes.string,
 
-    itemTextStyle: Text.propTypes.style,
+    //ssantamaria itemTextStyle: Text.propTypes.style,
 
     itemCount: PropTypes.number,
     itemPadding: PropTypes.number,


### PR DESCRIPTION
…valuating '_reactNative.Animated.Text.propTypes.style')